### PR TITLE
APB-8330: Renames request to requestHeader in logger.error

### DIFF
--- a/app/uk/gov/hmrc/agentoverseasfrontend/ErrorHandler.scala
+++ b/app/uk/gov/hmrc/agentoverseasfrontend/ErrorHandler.scala
@@ -68,7 +68,7 @@ with ErrorAuditing {
       statusCode,
       message
     )
-    logger.error(s"onClientError $message | status: $statusCode request: $request")
+    logger.error(s"onClientError $message | status: $statusCode | requestHeader: $request")
     super.onClientError(
       request,
       statusCode,


### PR DESCRIPTION
<img width="621" height="335" alt="Screenshot 2025-09-01 at 14 53 51" src="https://github.com/user-attachments/assets/5f7138ff-fb3f-4d57-b55f-e2ee8abe0ac1" />

<img width="635" height="238" alt="Screenshot 2025-09-01 at 14 53 58" src="https://github.com/user-attachments/assets/ed1ffe29-1314-437b-9ea4-0deddd443d07" />

Request logged does not contain request body - have renamed request in log to requestHeader to reflect this
